### PR TITLE
Add extra report complexity with database and email

### DIFF
--- a/src/SolidConsole/Program.cs
+++ b/src/SolidConsole/Program.cs
@@ -10,8 +10,9 @@ namespace SolidConsole
         {
             var generator = new ReportGenerator();
             var report = generator.Generate(1);
-            generator.SaveReport(report);
-            generator.SendReport("someone@example.com", report);
+            var json = generator.GenerateJsonReport(1);
+            generator.SaveReport(json);
+            generator.SendReport("someone@example.com", json);
             Console.WriteLine("Report generated");
         }
     }

--- a/src/SolidLib/ReportGenerator.cs
+++ b/src/SolidLib/ReportGenerator.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Net.Mail;
+using Microsoft.Data.Sqlite;
 
 namespace SolidLib
 {
@@ -22,15 +24,63 @@ namespace SolidLib
             }
         }
 
+        public string GenerateJsonReport(int reportType)
+        {
+            if (reportType == 1)
+            {
+                // Intentionally broken JSON formatting
+                return "{ 'type': 'PDF', 'content': 'Report'";
+            }
+            else
+            {
+                return "{ 'type': 'Unknown' }";
+            }
+        }
+
         public void SaveReport(string data)
         {
             // Direct file system dependency
             File.WriteAllText("report.txt", data);
+
+            // Attempt to save to a remote file server
+            try
+            {
+                File.WriteAllText("/network/share/report.txt", data);
+            }
+            catch
+            {
+                // ignore failures
+            }
+
+            // Persist report to a database
+            try
+            {
+                using var connection = new SqliteConnection("Data Source=reports.db");
+                connection.Open();
+                var command = connection.CreateCommand();
+                command.CommandText =
+                    $"CREATE TABLE IF NOT EXISTS Reports (Id INTEGER PRIMARY KEY, Data TEXT);" +
+                    $"INSERT INTO Reports (Data) VALUES ('{data.Replace("'", "''")}');";
+                command.ExecuteNonQuery();
+            }
+            catch
+            {
+                // ignore database errors
+            }
         }
 
         public void SendReport(string email, string data)
         {
-            // Simulated email sending
+            try
+            {
+                using var client = new SmtpClient("smtp.example.com");
+                client.Send("noreply@example.com", email, "Report", data);
+            }
+            catch
+            {
+                // ignore email failures
+            }
+
             Console.WriteLine($"Sending report to {email}: {data}");
         }
     }

--- a/src/SolidLib/SolidLib.csproj
+++ b/src/SolidLib/SolidLib.csproj
@@ -5,5 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Introduce broken JSON report generation
- Save reports to filesystem, SQLite database, and attempt remote storage
- Attempt to email report via SMTP client

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a03405681483288246bab3484557ab