### PR TITLE
Add classes violating SOLID principles

### DIFF
--- a/src/SolidConsole/Program.cs
+++ b/src/SolidConsole/Program.cs
@@ -13,6 +13,29 @@ namespace SolidConsole
             var json = generator.GenerateJsonReport(1);
             generator.SaveReport(json);
             generator.SendReport("someone@example.com", json);
+
+            // Additional classes demonstrating SOLID principle violations
+            var userManager = new UserManager();
+            userManager.CreateUser("Alice", "alice@example.com");
+
+            var exporter = new ReportExporter();
+            var exported = exporter.Export(1, report);
+
+            Notification notification = new SmsNotification();
+            try
+            {
+                notification.Send("This message is definitely too long");
+            }
+            catch
+            {
+                // ignore notification failures
+            }
+
+            IMultiFunctionDevice device = new SimplePrinter();
+            device.Print(exported);
+
+            var processor = new OrderProcessor();
+            processor.Process("order data");
             Console.WriteLine("Report generated");
         }
     }

--- a/src/SolidLib/IMultiFunctionDevice.cs
+++ b/src/SolidLib/IMultiFunctionDevice.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace SolidLib
+{
+    // This interface violates the Interface Segregation Principle by forcing
+    // implementations to provide many unrelated methods.
+    public interface IMultiFunctionDevice
+    {
+        void Print(string content);
+        void Scan(string content);
+        void Fax(string content);
+    }
+
+    // This class is forced to implement methods it doesn't need.
+    public class SimplePrinter : IMultiFunctionDevice
+    {
+        public void Print(string content)
+        {
+            Console.WriteLine($"Printing: {content}");
+        }
+
+        public void Scan(string content)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Fax(string content)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/SolidLib/Notification.cs
+++ b/src/SolidLib/Notification.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace SolidLib
+{
+    // Base notification class
+    public class Notification
+    {
+        public virtual void Send(string message)
+        {
+            Console.WriteLine($"Sending: {message}");
+        }
+    }
+
+    public class EmailNotification : Notification
+    {
+        public override void Send(string message)
+        {
+            Console.WriteLine($"Email: {message}");
+        }
+    }
+
+    // This class violates the Liskov Substitution Principle by throwing
+    // an exception for long messages, unlike the base class.
+    public class SmsNotification : Notification
+    {
+        public override void Send(string message)
+        {
+            if (message.Length > 10)
+            {
+                throw new InvalidOperationException("Message too long");
+            }
+
+            Console.WriteLine($"SMS: {message}");
+        }
+    }
+}

--- a/src/SolidLib/OrderProcessor.cs
+++ b/src/SolidLib/OrderProcessor.cs
@@ -1,0 +1,27 @@
+using Microsoft.Data.Sqlite;
+
+namespace SolidLib
+{
+    // This class violates the Dependency Inversion Principle by depending on a
+    // concrete database implementation instead of an abstraction.
+    public class OrderProcessor
+    {
+        public void Process(string order)
+        {
+            try
+            {
+                using var connection = new SqliteConnection("Data Source=orders.db");
+                connection.Open();
+                var command = connection.CreateCommand();
+                command.CommandText =
+                    $"CREATE TABLE IF NOT EXISTS Orders (Id INTEGER PRIMARY KEY, Data TEXT);" +
+                    $"INSERT INTO Orders (Data) VALUES ('{order.Replace("'", "''")}');";
+                command.ExecuteNonQuery();
+            }
+            catch
+            {
+                // ignore database failures
+            }
+        }
+    }
+}

--- a/src/SolidLib/ReportExporter.cs
+++ b/src/SolidLib/ReportExporter.cs
@@ -1,0 +1,23 @@
+namespace SolidLib
+{
+    // This class intentionally violates the Open/Closed Principle. Every new
+    // export format requires modifying this class.
+    public class ReportExporter
+    {
+        public string Export(int format, string data)
+        {
+            if (format == 1)
+            {
+                return $"PDF:{data}";
+            }
+            else if (format == 2)
+            {
+                return $"Excel:{data}";
+            }
+            else
+            {
+                return $"Unknown:{data}";
+            }
+        }
+    }
+}

--- a/src/SolidLib/UserManager.cs
+++ b/src/SolidLib/UserManager.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using System.Net.Mail;
+
+namespace SolidLib
+{
+    // This class intentionally violates the Single Responsibility Principle by
+    // handling user creation, persistence, and notification in one place.
+    public class UserManager
+    {
+        public void CreateUser(string name, string email)
+        {
+            Console.WriteLine($"Creating user {name}");
+            // Persist user to a text file
+            File.AppendAllText("users.txt", $"{name},{email}\n");
+
+            // Notify the user via email
+            try
+            {
+                using var client = new SmtpClient("smtp.example.com");
+                client.Send("noreply@example.com", email, "Welcome", "Hello and welcome!");
+            }
+            catch
+            {
+                // ignore email failures
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add UserManager mixing persistence and emailing to violate SRP
- Introduce ReportExporter with hard-coded branches to violate OCP
- Add Notification hierarchy with SmsNotification throwing for long messages (LSP)
- Create IMultiFunctionDevice interface and SimplePrinter implementation that violate ISP
- Add OrderProcessor that depends directly on SqliteConnection, breaking DIP
- Update Program to exercise new classes

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a0358dd8e483289f5e30f1794d616a