### PR TITLE
docs: credit origins of SOLID principles

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ The starting point violates several SOLID principles. The intention is to refact
 
 ## SOLID Principles Overview
 
-SOLID is an acronym for five design principles intended to make object-oriented designs more understandable, flexible, and maintainable:
+SOLID is an acronym coined by [Robert C. Martin](https://en.wikipedia.org/wiki/Robert_C._Martin) (Uncle Bob) for five design principles intended to make object-oriented designs more understandable, flexible, and maintainable:
 
 - **S**ingle Responsibility Principle
 - **O**pen/Closed Principle
 - **L**iskov Substitution Principle
 - **I**nterface Segregation Principle
 - **D**ependency Inversion Principle
+
+The acronym and the Single Responsibility, Interface Segregation, and Dependency Inversion principles were introduced by [Robert C. Martin](https://en.wikipedia.org/wiki/Robert_C._Martin) (Uncle Bob). The Open/Closed Principle was first described by [Bertrand Meyer](https://en.wikipedia.org/wiki/Bertrand_Meyer), and the Liskov Substitution Principle by [Barbara Liskov](https://en.wikipedia.org/wiki/Barbara_Liskov) and [Jeannette Wing](https://en.wikipedia.org/wiki/Jeannette_Wing).
 
 For detailed explanations and code examples, see the [documentation](docs/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # SOLID Principles
 
-This folder contains deep dives into each of the SOLID principles. Each document includes:
+This folder contains deep dives into each of the SOLID principles. The acronym was introduced by [Robert C. Martin](https://en.wikipedia.org/wiki/Robert_C._Martin) (Uncle Bob). Each document includes:
 
 - A brief description of the principle.
 - A C# example that **violates** the principle.

--- a/docs/dependency-inversion.md
+++ b/docs/dependency-inversion.md
@@ -2,6 +2,8 @@
 
 High-level modules should not depend on low-level modules; both should depend on abstractions.
 
+Introduced by [Robert C. Martin](https://en.wikipedia.org/wiki/Robert_C._Martin) (Uncle Bob).
+
 ## Violation
 
 ```csharp

--- a/docs/interface-segregation.md
+++ b/docs/interface-segregation.md
@@ -2,6 +2,8 @@
 
 Clients should not be forced to depend on methods they do not use.
 
+Introduced by [Robert C. Martin](https://en.wikipedia.org/wiki/Robert_C._Martin) (Uncle Bob).
+
 ## Violation
 
 ```csharp

--- a/docs/liskov-substitution.md
+++ b/docs/liskov-substitution.md
@@ -2,6 +2,8 @@
 
 Subtypes must be substitutable for their base types without altering correctness.
 
+Formulated by [Barbara Liskov](https://en.wikipedia.org/wiki/Barbara_Liskov) and [Jeannette Wing](https://en.wikipedia.org/wiki/Jeannette_Wing).
+
 ## Violation
 
 ```csharp

--- a/docs/open-closed.md
+++ b/docs/open-closed.md
@@ -2,6 +2,8 @@
 
 Software entities should be open for extension but closed for modification.
 
+Described by [Bertrand Meyer](https://en.wikipedia.org/wiki/Bertrand_Meyer).
+
 ## Violation
 
 ```csharp

--- a/docs/single-responsibility.md
+++ b/docs/single-responsibility.md
@@ -2,6 +2,8 @@
 
 A class should have only one reason to change.
 
+Introduced by [Robert C. Martin](https://en.wikipedia.org/wiki/Robert_C._Martin) (Uncle Bob).
+
 ## Violation
 
 ```csharp


### PR DESCRIPTION
## Summary
- mention Robert C. Martin as the originator of the SOLID acronym
- credit Bertrand Meyer, Barbara Liskov, and Jeannette Wing for their respective principles
- attribute remaining principles to Uncle Bob across docs

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a039dd2804832885640c4773fc80e5