### PR TITLE
Add realistic single-responsibility example

### DIFF
--- a/docs/single-responsibility.md
+++ b/docs/single-responsibility.md
@@ -11,50 +11,142 @@ Introduced by [Robert C. Martin](https://en.wikipedia.org/wiki/Robert_C._Martin)
 ## Violation
 
 ```csharp
-public class Report
+public class MonolithicOrderService
 {
-    public string Generate()
-    {
-        // produce report
-        return "report";
-    }
+    private readonly HttpClient _http = new();
+    private readonly SmtpClient _smtp = new("localhost");
 
-    public void SaveToFile(string path)
+    public void Process(string orderFile)
     {
-        File.WriteAllText(path, Generate());
+        var json = File.ReadAllText(orderFile);
+        var order = JsonSerializer.Deserialize<Order>(json) ?? new Order();
+
+        using var db = new SqliteConnection("Data Source=orders.db");
+        db.Open();
+        using var cmd = db.CreateCommand();
+        cmd.CommandText = "INSERT INTO Orders(Id, Customer) VALUES ($id, $customer)";
+        cmd.Parameters.AddWithValue("$id", order.Id);
+        cmd.Parameters.AddWithValue("$customer", order.Customer);
+        cmd.ExecuteNonQuery();
+
+        double total = 0;
+        foreach (var item in order.Items)
+        {
+            if (item.Quantity > 10)
+                total += item.Price * item.Quantity * 0.9;
+            else if (item.Quantity > 5)
+                total += item.Price * item.Quantity * 0.95;
+            else
+                total += item.Price * item.Quantity;
+        }
+
+        if (total > 1000)
+        {
+            var response = _http.PostAsync("https://api.example.com/discounts",
+                new StringContent(json)).Result;
+            if (!response.IsSuccessStatusCode)
+            {
+                Console.WriteLine("Discount API call failed");
+            }
+        }
+
+        var mail = new MailMessage("sales@example.com", order.Email)
+        {
+            Subject = "Order processed",
+            Body = $"Order total: {total}"
+        };
+        _smtp.Send(mail);
     }
 }
 ```
 
-`Report` both creates content and handles persistence. Changes to either concern force edits to the same class.
+`MonolithicOrderService` juggles file I/O, database access, business rules, HTTP calls and
+email notifications. Any change in one area forces edits to the same class.
 
 ## Fix
 
+Break up concerns into focused collaborators:
+
 ```csharp
-public class Report
+public class FileOrderReader
 {
-    public string Generate()
+    public Order Load(string path) =>
+        JsonSerializer.Deserialize<Order>(File.ReadAllText(path)) ?? new Order();
+}
+
+public class OrderRepository
+{
+    private readonly string _connectionString = "Data Source=orders.db";
+    public void Save(Order order)
     {
-        // produce report
-        return "report";
+        using var db = new SqliteConnection(_connectionString);
+        db.Open();
+        using var cmd = db.CreateCommand();
+        cmd.CommandText = "INSERT INTO Orders(Id, Customer) VALUES ($id, $customer)";
+        cmd.Parameters.AddWithValue("$id", order.Id);
+        cmd.Parameters.AddWithValue("$customer", order.Customer);
+        cmd.ExecuteNonQuery();
     }
 }
 
-public class ReportSaver
+public class DiscountService
 {
-    public void SaveToFile(Report report, string path)
+    private readonly HttpClient _http;
+    public DiscountService(HttpClient http) => _http = http;
+    public async Task ApplyDiscountAsync(Order order)
     {
-        File.WriteAllText(path, report.Generate());
+        await _http.PostAsync("https://api.example.com/discounts",
+            new StringContent(JsonSerializer.Serialize(order)));
+    }
+}
+
+public class EmailNotifier
+{
+    private readonly SmtpClient _smtp;
+    public EmailNotifier(SmtpClient smtp) => _smtp = smtp;
+    public void SendConfirmation(Order order, double total)
+    {
+        var mail = new MailMessage("sales@example.com", order.Email)
+        {
+            Subject = "Order processed",
+            Body = $"Order total: {total}"
+        };
+        _smtp.Send(mail);
+    }
+}
+
+public class OrderProcessor
+{
+    private readonly FileOrderReader _reader;
+    private readonly OrderRepository _repository;
+    private readonly DiscountService _discounts;
+    private readonly EmailNotifier _notifier;
+
+    public OrderProcessor(FileOrderReader reader, OrderRepository repository,
+        DiscountService discounts, EmailNotifier notifier)
+    {
+        _reader = reader;
+        _repository = repository;
+        _discounts = discounts;
+        _notifier = notifier;
+    }
+
+    public async Task ProcessAsync(string orderFile)
+    {
+        var order = _reader.Load(orderFile);
+        _repository.Save(order);
+        await _discounts.ApplyDiscountAsync(order);
+        _notifier.SendConfirmation(order, 0);
     }
 }
 ```
 
-Splitting responsibilities isolates reasons to change: `Report` generates data, while `ReportSaver` persists it.
+Each class now focuses on one responsibility, making changes local and tests easier to write.
 
 ## Benefits
 
-- **Simpler maintenance** – adjustments to how a report is created or saved do not influence each other.
+- **Simpler maintenance** – changing how orders are loaded, persisted, discounted or notified is isolated.
 - **Easier testing** – each class can be exercised in isolation with focused unit tests.
-- **Greater reuse** – other components can consume `Report` without bringing in file system concerns.
+- **Greater reuse** – order processing logic can be reused without carrying file system, database or email concerns.
 
 [Back to overview](README.md)

--- a/src/SolidLib/BadExamples/BadSingleResponsibility.cs
+++ b/src/SolidLib/BadExamples/BadSingleResponsibility.cs
@@ -1,17 +1,80 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
+using System.Net.Mail;
+using System.Text.Json;
+using Microsoft.Data.Sqlite;
 
 namespace SolidLib.BadExamples
 {
     // This class violates the Single Responsibility Principle by
-    // performing calculation, persistence, and notification.
-    public class InvoiceService
+    // handling file I/O, database persistence, business rules,
+    // email notifications, and external API calls all in one place.
+    public class MonolithicOrderService
     {
-        public void Process(string customer, double amount)
+        private readonly HttpClient _http = new();
+        private readonly SmtpClient _smtp = new("localhost");
+
+        public void Process(string orderFile)
         {
-            var total = amount * 1.2; // apply tax
-            File.AppendAllText("invoices.txt", $"{customer}:{total}\n");
-            Console.WriteLine($"Invoice for {customer} processed: {total}");
+            // load order from disk
+            var json = File.ReadAllText(orderFile);
+            var order = JsonSerializer.Deserialize<Order>(json) ?? new Order();
+
+            // save to SQLite
+            using var db = new SqliteConnection("Data Source=orders.db");
+            db.Open();
+            using var cmd = db.CreateCommand();
+            cmd.CommandText = "INSERT INTO Orders(Id, Customer) VALUES ($id, $customer)";
+            cmd.Parameters.AddWithValue("$id", order.Id);
+            cmd.Parameters.AddWithValue("$customer", order.Customer);
+            cmd.ExecuteNonQuery();
+
+            // business rules with many branches
+            double total = 0;
+            foreach (var item in order.Items)
+            {
+                if (item.Quantity > 10)
+                    total += item.Price * item.Quantity * 0.9;
+                else if (item.Quantity > 5)
+                    total += item.Price * item.Quantity * 0.95;
+                else
+                    total += item.Price * item.Quantity;
+            }
+
+            if (total > 1000)
+            {
+                var response = _http.PostAsync("https://api.example.com/discounts",
+                    new StringContent(json)).Result;
+                if (!response.IsSuccessStatusCode)
+                {
+                    Console.WriteLine("Discount API call failed");
+                }
+            }
+
+            // send confirmation email
+            var mail = new MailMessage("sales@example.com", order.Email)
+            {
+                Subject = "Order processed",
+                Body = $"Order total: {total}"
+            };
+            _smtp.Send(mail);
+        }
+
+        private class Order
+        {
+            public int Id { get; set; }
+            public string Customer { get; set; } = "";
+            public string Email { get; set; } = "";
+            public List<OrderItem> Items { get; set; } = new();
+        }
+
+        private class OrderItem
+        {
+            public string Name { get; set; } = "";
+            public int Quantity { get; set; }
+            public double Price { get; set; }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Expand Single Responsibility Principle docs with a complex `MonolithicOrderService` example that uses file I/O, SQLite, email, and HTTP APIs
- Update bad example code to match the new scenario

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a17fd6df008328bf07407a03459e72