### PR TITLE
Add comprehensive tests and document testability

### DIFF
--- a/state-of-testability.md
+++ b/state-of-testability.md
@@ -1,0 +1,15 @@
+# State of Testability
+
+## Existing Test Coverage
+- **Unit tests** verify small pieces of logic such as `ReportGenerator.Generate` and `ReportExporter.Export`.
+- **Characterization tests** capture current flawed behavior like malformed JSON output and exceptions from `SmsNotification`.
+- **Integration tests** exercise interactions with the file system and database when saving and exporting reports.
+- **End-to-end tests** execute the console application and assert that a completion message is written.
+
+## Observations
+- Many components such as `UserManager` and `OrderProcessor` depend directly on external systems (SMTP servers, file system paths, SQLite), making them difficult to isolate or mock.
+- `ReportGenerator.SaveReport` performs file and database operations without abstraction, which complicates error handling and testing.
+- `SendReport` and user creation routines rely on network resources; tests avoid these paths to prevent side effects.
+- Interfaces like `IMultiFunctionDevice` force unnecessary implementations, reducing testability for simple devices.
+
+Overall, while basic behaviors are covered, significant parts of the software remain hard to test due to tight coupling and side effects.

--- a/test/SolidTests/CharacterizationTests.cs
+++ b/test/SolidTests/CharacterizationTests.cs
@@ -1,0 +1,27 @@
+using System;
+using SolidLib;
+
+namespace SolidTests
+{
+    [TestClass]
+    public class CharacterizationTests
+    {
+        [TestMethod]
+        [TestCategory("Characterization")]
+        public void GenerateJsonReport_ReturnsMalformedJson()
+        {
+            var generator = new ReportGenerator();
+            var json = generator.GenerateJsonReport(1);
+            Assert.AreEqual("{ 'type': 'PDF', 'content': 'Report'", json);
+        }
+
+        [TestMethod]
+        [TestCategory("Characterization")]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void SmsNotification_LongMessage_Throws()
+        {
+            var notification = new SmsNotification();
+            notification.Send("This message is definitely too long");
+        }
+    }
+}

--- a/test/SolidTests/EndToEndTests.cs
+++ b/test/SolidTests/EndToEndTests.cs
@@ -1,0 +1,23 @@
+using System;
+using System.IO;
+using SolidConsole;
+
+namespace SolidTests
+{
+    [TestClass]
+    public class EndToEndTests
+    {
+        [TestMethod]
+        [TestCategory("EndToEnd")]
+        public void Main_WritesCompletionMessage()
+        {
+            using var sw = new StringWriter();
+            Console.SetOut(sw);
+
+            Program.Main(Array.Empty<string>());
+
+            var output = sw.ToString();
+            StringAssert.Contains(output, "Report generated");
+        }
+    }
+}

--- a/test/SolidTests/IntegrationTests.cs
+++ b/test/SolidTests/IntegrationTests.cs
@@ -1,0 +1,35 @@
+using System.IO;
+using SolidLib;
+
+namespace SolidTests
+{
+    [TestClass]
+    public class IntegrationTests
+    {
+        [TestMethod]
+        [TestCategory("Integration")]
+        public void SaveReport_CreatesFilesAndDatabase()
+        {
+            var generator = new ReportGenerator();
+            var json = generator.GenerateJsonReport(1);
+            generator.SaveReport(json);
+
+            Assert.IsTrue(File.Exists("report.txt"));
+            Assert.IsTrue(File.Exists("reports.db"));
+
+            File.Delete("report.txt");
+            File.Delete("reports.db");
+        }
+
+        [TestMethod]
+        [TestCategory("Integration")]
+        public void Exporter_UsesGeneratorOutput()
+        {
+            var generator = new ReportGenerator();
+            var exporter = new ReportExporter();
+            var report = generator.Generate(1);
+            var exported = exporter.Export(1, report);
+            Assert.AreEqual("PDF:PDF Report", exported);
+        }
+    }
+}

--- a/test/SolidTests/UnitTest1.cs
+++ b/test/SolidTests/UnitTest1.cs
@@ -1,31 +1,26 @@
-using System;
-using System.IO;
 using SolidLib;
-using SolidConsole;
 
 namespace SolidTests
 {
     [TestClass]
-    public class ReportTests
+    public class ReportGeneratorUnitTests
     {
         [TestMethod]
+        [TestCategory("Unit")]
         public void Generate_ReturnsPdfReport()
         {
             var generator = new ReportGenerator();
             var report = generator.Generate(1);
             Assert.AreEqual("PDF Report", report);
         }
-
+        
         [TestMethod]
-        public void Main_WritesCompletionMessage()
+        [TestCategory("Unit")]
+        public void Exporter_ReturnsPrefixedReport()
         {
-            using var sw = new StringWriter();
-            Console.SetOut(sw);
-
-            Program.Main(Array.Empty<string>());
-
-            var output = sw.ToString();
-            StringAssert.Contains(output, "Report generated");
+            var exporter = new ReportExporter();
+            var result = exporter.Export(1, "PDF Report");
+            Assert.AreEqual("PDF:PDF Report", result);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add unit tests for `ReportGenerator` and `ReportExporter`
- Add characterization tests for malformed JSON and SMS notifications
- Add integration tests for saving and exporting reports
- Add end-to-end test for console application
- Document testability findings in `state-of-testability.md`
- Tag tests with `TestCategory` attributes for Unit, Integration, Characterization, and EndToEnd runs

## Testing
- `dotnet test`
- `dotnet test --filter TestCategory=Unit`
- `dotnet test --filter TestCategory=Integration`
- `dotnet test --filter TestCategory=Characterization`
- `dotnet test --filter TestCategory=EndToEnd`


------
https://chatgpt.com/codex/tasks/task_e_68a2034ef3788328bdee367ebc61ae50